### PR TITLE
Deleted skin lesion model file

### DIFF
--- a/agents/image_analysis_agent/skin_lesion_agent/models/checkpointN25_.pth.tar
+++ b/agents/image_analysis_agent/skin_lesion_agent/models/checkpointN25_.pth.tar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:31282b034a0e6aa3948e6e984d4c43069ba99285b869ac53069f7637d8c806dd
-size 183930951


### PR DESCRIPTION
Deleted skin lesion model file due to LFS quota exhausted - Download project zip from releases until optimized model file is pushed.